### PR TITLE
Added missing stddef.h for size_t on OS X.

### DIFF
--- a/src/tmx.h
+++ b/src/tmx.h
@@ -13,6 +13,7 @@
 #ifndef TMX_H
 #define TMX_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Added the stddef.h header to tmx.h so that it builds on OS X.