### PR TITLE
Some additions & fixes (see details)

### DIFF
--- a/src/tmx.c
+++ b/src/tmx.c
@@ -110,6 +110,7 @@ static void free_tiles(tmx_tile *t) {
 	if (t) {
 		free_tiles(t->next);
 		free_props(t->properties);
+		free_image(t->image);
 		tmx_free_func(t);
 	}
 }

--- a/src/tmx.h
+++ b/src/tmx.h
@@ -61,6 +61,7 @@ typedef struct _tmx_img { /* <image> */
 } tmx_image;
 
 typedef struct _tmx_tile { /* <tile> */
+	tmx_image* image;
 	unsigned int id;
 	tmx_property *properties;
 	struct _tmx_tile *next;
@@ -71,7 +72,7 @@ typedef struct _tmx_ts { /* <tileset> and <tileoffset> */
 	char *name;
 	unsigned int tile_width, tile_height;
 	unsigned int spacing, margin;
-	unsigned int x_offset, y_offset; /* tileoffset */
+	int x_offset, y_offset; /* tileoffset */
 	/* terraintypes(0.9), tile(0.9) are for the QtTiled terrain feature */
 	tmx_image *image;
 	tmx_property *properties;
@@ -97,6 +98,7 @@ typedef struct _tmx_layer { /* <layer>+<data> <objectgroup>+<object> */
 	int color; /* bytes : RGB */
 	double opacity;
 	char visible; /* 0 == false */
+	int x_offset, y_offset; /* For image layers */
 
 	enum tmx_layer_type type;
 	union layer_content {

--- a/src/tmx.h
+++ b/src/tmx.h
@@ -54,6 +54,7 @@ typedef struct _tmx_prop { /* <properties> and <property> */
 typedef struct _tmx_img { /* <image> */
 	char *source;
 	int trans; /* bytes : RGB */
+	int uses_trans;
 	unsigned long width, height;
 	/*char *format; Not currently implemented in QtTiled
 	char *data;*/

--- a/src/tmx_json.c
+++ b/src/tmx_json.c
@@ -321,6 +321,7 @@ static int pjson_tileset(json_t *tls_el, tmx_tileset **tst_headaddr, const char 
 
 		if (!(json_unpack_ex(tls_el, &err, 0, "{s:s}", "transparentcolor", &trans_string))) {
 			if (trans_string != NULL) {
+				ts->image->uses_trans = 1;
 				if (trans_string[0] == '#') {
 					ts->image->trans = (int)(strtoul(&(trans_string[1]), NULL, 16));
 				}

--- a/src/tmx_json.c
+++ b/src/tmx_json.c
@@ -132,9 +132,9 @@ static int pjson_layer(json_t *lay_el, tmx_layer **lay_headaddr, const char *fil
 	*lay_headaddr = lay;
 
 	if (json_unpack_ex(lay_el, &err, 0, "{s:b, s:F, s:i, s:i, s:s, s:s}",
-	                   "visible", &(lay->visible),  "opacity", &(lay->opacity), // Something changed on this line
-	                   "x",       &(lay->x_offset), "y",       &(lay->y_offset), // Something changed on this line
-	                   "type",    &type,            "name",    &name)) { // Something changed on this line
+	                   "visible", &(lay->visible),  "opacity", &(lay->opacity),
+	                   "x",       &(lay->x_offset), "y",       &(lay->y_offset),
+	                   "type",    &type,            "name",    &name)) {
 		tmx_err(E_MISSEL, "json parser: (layer) %s", err.text);
 		return 0;
 	}

--- a/src/tmx_json.c
+++ b/src/tmx_json.c
@@ -55,7 +55,7 @@ static int pjson_points(json_t *pts_ar, int ***pts_araddr, int *ptslen_addr) {
 	json_t *tmp;
 	int i;
 
-	*ptslen_addr = json_array_size(pts_ar);
+	*ptslen_addr = (int)(json_array_size(pts_ar));
 	if (!(*pts_araddr = (int**)tmx_alloc_func(NULL, *ptslen_addr * sizeof(int*)))) {
 		tmx_errno = E_ALLOC;
 		return 0;
@@ -131,8 +131,9 @@ static int pjson_layer(json_t *lay_el, tmx_layer **lay_headaddr, const char *fil
 	lay->next = *lay_headaddr;
 	*lay_headaddr = lay;
 
-	if (json_unpack_ex(lay_el, &err, 0, "{s:b, s:F, s:s, s:s}",
+	if (json_unpack_ex(lay_el, &err, 0, "{s:b, s:F, s:i, s:i, s:s, s:s}",
 	                   "visible", &(lay->visible), "opacity", &(lay->opacity),
+					   "x",       &(lay->x_offset), "y",      &(lay->y_offset),
 	                   "type",    &type,           "name",    &name)) {
 		tmx_err(E_MISSEL, "json parser: (layer) %s", err.text);
 		return 0;
@@ -185,6 +186,7 @@ static int pjson_layer(json_t *lay_el, tmx_layer **lay_headaddr, const char *fil
 
 	return 1;
 }
+
 static int pjson_tile(json_t *tile_el, tmx_tile **tile_headaddr) {
 	tmx_tile *tile;
 	const char *key;
@@ -205,39 +207,163 @@ static int pjson_tile(json_t *tile_el, tmx_tile **tile_headaddr) {
 	return 1;
 }
 
+
+/* This is a rather slow solution - anyone with more spare time, feel free to rework the whole structure of
+   the tiles list to make this faster */
+static tmx_tile* pjson_tiles_find_or_alloc(tmx_tile **tile_headaddr, unsigned int id) {
+	tmx_tile *tile = *tile_headaddr;
+
+	if (tile == NULL) {
+		if (!(*tile_headaddr = alloc_tile())) return NULL;
+		(*tile_headaddr)->id = id;
+		return *tile_headaddr;
+	}
+	else {
+		while (tile != NULL) {
+			if (tile->id == id) return tile;
+			if (tile->next != NULL)
+				tile = tile->next;
+			else {
+				if (!(tile->next = alloc_tile())) return NULL;
+				tile->next->id = id;
+				return tile->next;
+			}
+		}
+	}
+
+	return NULL;
+}
+
+static int pjson_tiles_images(json_t *tile_el, tmx_tile **tile_headaddr, const char *filename) {
+	tmx_tile *tile = NULL;
+	const char *key;
+	json_t *val;
+	json_error_t err;
+	char *img;
+
+	json_object_foreach(tile_el, key, val) {
+		unsigned int key_value = atoi(key);
+		tile = pjson_tiles_find_or_alloc(tile_headaddr, key_value);
+		if (json_is_object(val) && tile != NULL) {
+			if (!(tile->image = alloc_image())) return 0;
+			if (json_unpack_ex(val, &err, 0, "{s:i, s:i, s:s}", "imageheight", &(tile->image->height), "imagewidth", &(tile->image->width), "image", &img))
+				json_unpack_ex(val, &err, 0, "{s:s}", "image", &img);
+
+			if (img != NULL) {
+				if (!(tile->image->source = tmx_strdup(img))) return 0;
+				if (!load_image(&(tile->image->resource_image), filename, img)) {
+					tmx_err(E_UNKN, "json parser: an error occured in the delegated image loading function");
+					return 0;
+				}
+			}
+			else {
+				tmx_err(E_MISSEL, "json parser: couldn't read image source file string for tmx_tile");
+				return 0;
+			}
+
+			tile = tile->next;
+		}
+		else {
+			tmx_err(E_ALLOC, "json parser: couldn't allocate or find tmx_tile for image collection tileset");
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
 static int pjson_tileset(json_t *tls_el, tmx_tileset **tst_headaddr, const char *filename) {
 	json_error_t err;
 	json_t *tmp;
 	tmx_tileset *ts;
 	char *img, *name;
+	unsigned int image_width, image_height;
 
 	if (!(ts = alloc_tileset()))      return 0;
-	if (!(ts->image = alloc_image())) return 0;
 	ts->next = *tst_headaddr;
 	*tst_headaddr = ts;
 
-	if (json_unpack_ex(tls_el, &err, 0, "{s:i, s:i, s:i, s:i, s:i, s:i, s:i, s:s, s:s}",
+	if (!(json_unpack_ex(tls_el, &err, 0, "{s:i, s:i, s:i, s:i, s:i, s:i, s:i, s:s, s:s}",
 	                   "spacing",     &(ts->spacing),       "margin",     &(ts->margin),
 	                   "tileheight",  &(ts->tile_height),   "tilewidth",  &(ts->tile_width),
-	                   "imageheight", &(ts->image->height), "imagewidth", &(ts->image->width),
+					   "imageheight", &(image_height),		"imagewidth", &(image_width),
 	                   "firstgid",    &(ts->firstgid),      "image",      &img,
-	                   "name",        &name)) {
+	                   "name",        &name))) {
+		if (!(ts->image = alloc_image())) return 0;
+		ts->image->width = image_width;
+		ts->image->height = image_height;
+		if (!(ts->name = tmx_strdup(name)))         return 0;
+		if (!(ts->image->source = tmx_strdup(img))) return 0;
+		if (!load_image(&(ts->image->resource_image), filename, img)) {
+			tmx_err(E_UNKN, "json parser: an error occured in the delegated image loading function");
+			return 0;
+		}
+
+		if ((tmp = json_object_get(tls_el, "properties")) && json_is_object(tmp)) {
+			if (!pjson_properties(tmp, &(ts->properties))) return 0;
+		}
+
+		if ((tmp = json_object_get(tls_el, "tileproperties")) && json_is_object(tmp)) {
+			if (!pjson_tile(tmp, &(ts->tiles))) return 0;
+		}
+
+		if ((tmp = json_object_get(tls_el, "tileoffset")) && json_is_object(tmp)) {
+			const char *key;
+			json_t *val;
+			json_object_foreach(tmp, key, val) {
+				// TODO: Add some error handling here
+				if (!strcmp(key, "x")) ts->x_offset = (int)json_integer_value(val);
+				if (!strcmp(key, "y")) ts->y_offset = (int)json_integer_value(val);
+			}
+		}
+
+		char* trans_string;
+
+		if (!(json_unpack_ex(tls_el, &err, 0, "{s:s}", "transparentcolor", &trans_string))) {
+			if (trans_string != NULL) {
+				if (trans_string[0] == '#') {
+					ts->image->trans = (int)(strtoul(&(trans_string[1]), NULL, 16));
+				}
+				else
+					ts->image->trans = (int)(strtoul(&(trans_string[0]), NULL, 16));
+			}
+		}
+	}
+	else if (!(json_unpack_ex(tls_el, &err, 0, "{s:i, s:i, s:i, s:i, s:i, s:s}",
+							"spacing", &(ts->spacing), "margin", &(ts->margin),
+							"tileheight", &(ts->tile_height), "tilewidth", &(ts->tile_width),
+							"firstgid", &(ts->firstgid),
+							"name", &name))) {
+		ts->image = NULL;
+
+		if (!(ts->name = tmx_strdup(name)))         return 0;
+
+		if ((tmp = json_object_get(tls_el, "properties")) && json_is_object(tmp)) {
+			if (!pjson_properties(tmp, &(ts->properties))) return 0;
+		}
+
+		if ((tmp = json_object_get(tls_el, "tileproperties")) && json_is_object(tmp)) {
+			if (!pjson_tile(tmp, &(ts->tiles))) return 0;
+		}
+
+		if ((tmp = json_object_get(tls_el, "tiles")) && json_is_object(tmp)) {
+			if (!pjson_tiles_images(tmp, &(ts->tiles), filename)) return 0;
+		}
+
+		if ((tmp = json_object_get(tls_el, "tileoffset")) && json_is_object(tmp)) {
+			const char *key;
+			json_t *val;
+			json_object_foreach(tmp, key, val) {
+				// TODO: Add some error handling here
+				if (!strcmp(key, "x")) ts->x_offset = (int)json_integer_value(val);
+				if (!strcmp(key, "y")) ts->y_offset = (int)json_integer_value(val);
+			}
+		}
+	}
+	else {
+
 		tmx_err(E_MISSEL, "json parser: (tileset) %s", err.text);
 		return 0;
-	}
-	if (!(ts->name = tmx_strdup(name)))         return 0;
-	if (!(ts->image->source = tmx_strdup(img))) return 0;
-	if (!load_image(&(ts->image->resource_image), filename, img)) {
-		tmx_err(E_UNKN, "json parser: an error occured in the delegated image loading function");
-		return 0;
-	}
-
-	if ((tmp = json_object_get(tls_el, "properties")) && json_is_object(tmp)) {
-		if (!pjson_properties(tmp, &(ts->properties))) return 0;
-	}
-
-	if ((tmp = json_object_get(tls_el, "tileproperties")) && json_is_object(tmp)) {
-		if (!pjson_tile(tmp, &(ts->tiles))) return 0;
 	}
 
 	return 1;
@@ -275,7 +401,7 @@ static tmx_map* pjson_map(json_t *map_el, const char *filename) {
 	}
 
 	if ((tmp = json_object_get(map_el, "layers")) && json_is_array(tmp)) {
-		i = json_array_size(tmp);
+		i = (int)(json_array_size(tmp));
 		for (--i; i>=0 ; i--) { /* tail appending */
 			if (!pjson_layer(json_array_get(tmp, i), &(res->ly_head), filename)) goto cleanup;
 		}

--- a/src/tmx_json.c
+++ b/src/tmx_json.c
@@ -132,9 +132,9 @@ static int pjson_layer(json_t *lay_el, tmx_layer **lay_headaddr, const char *fil
 	*lay_headaddr = lay;
 
 	if (json_unpack_ex(lay_el, &err, 0, "{s:b, s:F, s:i, s:i, s:s, s:s}",
-	                   "visible", &(lay->visible), "opacity", &(lay->opacity),
-					   "x",       &(lay->x_offset), "y",      &(lay->y_offset),
-	                   "type",    &type,           "name",    &name)) {
+	                   "visible", &(lay->visible),  "opacity", &(lay->opacity), // Something changed on this line
+	                   "x",       &(lay->x_offset), "y",       &(lay->y_offset), // Something changed on this line
+	                   "type",    &type,            "name",    &name)) { // Something changed on this line
 		tmx_err(E_MISSEL, "json parser: (layer) %s", err.text);
 		return 0;
 	}

--- a/src/tmx_utils.c
+++ b/src/tmx_utils.c
@@ -86,7 +86,7 @@ char* b64_decode(const char *source, unsigned int *rlength) { /* NULL terminated
 	short j;
 	unsigned int i;
 	unsigned int in = 0;
-	unsigned int src_len = strlen(source);
+	unsigned int src_len = (unsigned int)(strlen(source));
 
 	if (!source) {
 		tmx_err(E_INVAL, "Base64: invalid argument: source is NULL");
@@ -240,7 +240,7 @@ int data_decode(const char *source, enum enccmp_t type, size_t gids_count, int32
 	}
 	else if (type==B64Z) {
 		if (!(b64dec = b64_decode(source, &b64_len))) return 0;
-		*gids = (int32_t*)zlib_decompress(b64dec, b64_len, gids_count*sizeof(int32_t));
+		*gids = (int32_t*)zlib_decompress(b64dec, b64_len, (unsigned int)(gids_count*sizeof(int32_t)));
 		tmx_free_func(b64dec);
 		if (!(*gids)) return 0;
 	}
@@ -289,6 +289,8 @@ tmx_layer* alloc_layer(void) {
 		memset(res, 0, sizeof(tmx_layer));
 		res->opacity = 1.0f;
 		res->visible = 1;
+		res->x_offset = 0;
+		res->y_offset = 0;
 	} else {
 		tmx_errno = E_ALLOC;
 	}
@@ -361,7 +363,7 @@ int count_char_occurences(const char *str, char c) {
 
 /* trim 'str' to avoid blank characters at its beginning and end */
 char* str_trim(char *str) {
-	int end = strlen(str)-1;
+	int end = (int)(strlen(str)-1);
 	while (end>=0 && isspace((unsigned char) str[end])) end--;
 	str[end+1] = '\0';
 

--- a/src/tmx_xml.c
+++ b/src/tmx_xml.c
@@ -343,6 +343,16 @@ static int parse_layer(xmlTextReaderPtr reader, tmx_layer **layer_headadr, int m
 		tmx_free_func(value);
 	}
 
+	if ((value = (char*)xmlTextReaderGetAttribute(reader, (xmlChar*)"x"))) { /* x_offset */
+		res->x_offset = (int)strtod(value, NULL);
+		tmx_free_func(value);
+	}
+
+	if ((value = (char*)xmlTextReaderGetAttribute(reader, (xmlChar*)"y"))) { /* y_offset */
+		res->y_offset = (int)strtod(value, NULL);
+		tmx_free_func(value);
+	}
+
 	do {
 		if (xmlTextReaderRead(reader) != 1) return 0; /* error_handler has been called */
 
@@ -393,7 +403,7 @@ static int parse_tileoffset(xmlTextReaderPtr reader, unsigned int *x, unsigned i
 	return 1;
 }
 
-static int parse_tile(xmlTextReaderPtr reader, tmx_tile **tile_headadr) {
+static int parse_tile(xmlTextReaderPtr reader, tmx_tile **tile_headadr, const char *filename) {
 	tmx_tile *res = NULL;
 	int curr_depth;
 	const char *name;
@@ -424,6 +434,9 @@ static int parse_tile(xmlTextReaderPtr reader, tmx_tile **tile_headadr) {
 			name = (char*)xmlTextReaderConstName(reader);
 			if (!strcmp(name, "properties")) {
 				if (!parse_properties(reader, &(res->properties))) return 0;
+			}
+			else if (!strcmp(name, "image")) {
+				if (!parse_image(reader, &(res->image), 0, filename)) return 0;
 			}
 			else {
 				/* Unknow element, skipping it's tree */
@@ -491,7 +504,7 @@ static int parse_tileset_sub(xmlTextReaderPtr reader, tmx_tileset *ts_addr, cons
 			} else if (!strcmp(name, "properties")) {
 				if (!parse_properties(reader, &(ts_addr->properties))) return 0;
 			} else if (!strcmp(name, "tile")) {
-				if (!parse_tile(reader, &(ts_addr->tiles))) return 0;
+				if (!parse_tile(reader, &(ts_addr->tiles), filename)) return 0;
 			} else {
 				/* Unknown element, skipping it's tree */
 				if (xmlTextReaderNext(reader) != 1) return 0;

--- a/src/tmx_xml.c
+++ b/src/tmx_xml.c
@@ -297,6 +297,7 @@ static int parse_image(xmlTextReaderPtr reader, tmx_image **img_adr, short stric
 
 	if ((value = (char*)xmlTextReaderGetAttribute(reader, (xmlChar*)"trans"))) { /* trans */
 		res->trans = get_color_rgb(value);
+		res->uses_trans = 1;
 		tmx_free_func(value);
 	}
 

--- a/src/tmx_xml.c
+++ b/src/tmx_xml.c
@@ -345,12 +345,12 @@ static int parse_layer(xmlTextReaderPtr reader, tmx_layer **layer_headadr, int m
 	}
 
 	if ((value = (char*)xmlTextReaderGetAttribute(reader, (xmlChar*)"x"))) { /* x_offset */
-		res->x_offset = (int)strtod(value, NULL);
+		res->x_offset = (int)atoi(value);
 		tmx_free_func(value);
 	}
 
 	if ((value = (char*)xmlTextReaderGetAttribute(reader, (xmlChar*)"y"))) { /* y_offset */
-		res->y_offset = (int)strtod(value, NULL);
+		res->y_offset = (int)atoi(value);
 		tmx_free_func(value);
 	}
 
@@ -383,7 +383,7 @@ static int parse_layer(xmlTextReaderPtr reader, tmx_layer **layer_headadr, int m
 	return 1;
 }
 
-static int parse_tileoffset(xmlTextReaderPtr reader, unsigned int *x, unsigned int *y) {
+static int parse_tileoffset(xmlTextReaderPtr reader, int *x, int *y) {
 	char *value;
 	if ((value = (char*)xmlTextReaderGetAttribute(reader, (xmlChar*)"x"))) { /* x offset */
 		*x = atoi(value);


### PR DESCRIPTION
-Fixed: tmx_tileset properties x_offset/y_offset were "unsigned int"
instead of "int" (this was a bug because tilesets can have negative
offsets in Tiled)
-Added x_offset/y_offset properties to tmx_layer (these are needed for
positioning image layers which was previously not supported)
-Added support for image collection tilesets (tmx_tiles now contain
tmx_image to source image)
-Fixed: JSON parser didn't set x_offset/y_offset of tmx_tileset
-Fixed: JSON parser didn't set trans of tmx_image