### PR TITLE
Added loading from memory buffer

### DIFF
--- a/src/tmx.c
+++ b/src/tmx.c
@@ -38,6 +38,24 @@ tmx_map* tmx_load(const char *path) {
 	return map;
 }
 
+tmx_map* tmx_load_memory(char *buffer, size_t size, const char* absolute_path)  {
+	tmx_map *map = NULL;
+
+	if (!tmx_alloc_func) tmx_alloc_func = realloc;
+	if (!tmx_free_func) tmx_free_func = free;
+
+	map = parse_xml_memory(buffer, size, absolute_path);
+
+	if (map) {
+		if (!mk_map_tile_array(map)) {
+			tmx_map_free(map);
+			map = NULL;
+		}
+	}
+
+	return map;
+}
+
 static void free_props(tmx_property *p) {
 	if (p) {
 		free_props(p->next);

--- a/src/tmx.h
+++ b/src/tmx.h
@@ -200,6 +200,10 @@ struct _tmx_map { /* <map> (Head of the data structure) */
    returns NULL if an error occured and set tmx_errno */
 TMXEXPORT tmx_map *tmx_load(const char *path);
 
+/* Load a map from memory and return the head of the data structure
+   returns NULL if an error occured and set tmx_errno */
+TMXEXPORT tmx_map *tmx_load_memory(char *buffer, size_t size, const char* absolute_path);
+
 /* Free the map data structure */
 TMXEXPORT void tmx_map_free(tmx_map *map);
 

--- a/src/tmx_utils.h
+++ b/src/tmx_utils.h
@@ -18,6 +18,7 @@
 enum enccmp_t {CSV, B64Z};
 int data_decode(const char *source, enum enccmp_t type, size_t gids_count, int32_t **gids);
 tmx_map* parse_xml(const char *filename); /* tmx_xml.c */
+tmx_map* parse_xml_memory(char* buffer, size_t size, const char* absolute_path); /* tmx_xml.c */
 
 /*
 	Node allocation


### PR DESCRIPTION
Takes in a char\* buffer containing the loaded .tmx. Requires the size of that memory buffer to be passed aswell. absolute_path is the location of the .tmx file on disk, to allow for parsing .tsx files if present.
