### PR TITLE
tmx_utils: Check map->ts_head is non NULL

### DIFF
--- a/src/tmx_utils.c
+++ b/src/tmx_utils.c
@@ -354,6 +354,11 @@ int mk_map_tile_array(tmx_map *map) {
 		return 0;
 	}
 
+	if (!map->ts_head) {
+		tmx_err(E_INVAL, "mk_map_tile_array: invalid argument: map->ts_head is NULL");
+		return 0;
+	}
+
 	/* Counts total tile count */
 	ts = max_ts = map->ts_head;
 	while (ts != NULL) {


### PR DESCRIPTION
Clang analyze reports a possible NULL pointer dereference if
mk_map_tile_array is called with map->ts_head equal to NULL.
The offending line is max_ts->image, where max_ts is set to NULL
after ts = max_ts = map->ts_head. Adding a trivial check makes
Clang analyze happy.