### PR TITLE
Casted atof to float

### DIFF
--- a/src/tmx_xml.c
+++ b/src/tmx_xml.c
@@ -61,7 +61,7 @@ static int parse_property(xmlTextReaderPtr reader, tmx_property *prop) {
 				tmx_free_func(value);
 				break;
 			case PT_FLOAT:
-				prop->value.decimal = atof(value);
+				prop->value.decimal = (float)atof(value);
 				tmx_free_func(value);
 				break;
 			case PT_BOOL:


### PR DESCRIPTION
Under Visual C++ 15.8.9, atof produces a double variable, with this change, the variable is casted to float.