### PR TITLE
Renamed template for msvc

### DIFF
--- a/src/tmx.h
+++ b/src/tmx.h
@@ -186,7 +186,7 @@ struct _tmx_obj { /* <object> */
 	double rotation;
 
 	char *name, *type;
-	tmx_template *template;
+	tmx_template *template_ref;
 	tmx_properties *properties;
 	tmx_object *next;
 };

--- a/src/tmx_mem.c
+++ b/src/tmx_mem.c
@@ -156,8 +156,8 @@ void free_obj(tmx_object *o) {
 		}
 		tmx_free_func(o->type);
 		free_props(o->properties);
-		if (o->template && o->template->is_embedded) {
-			free_template(o->template);
+		if (o->template_ref && o->template_ref->is_embedded) {
+			free_template(o->template_ref);
 		}
 		tmx_free_func(o);
 	}

--- a/src/tmx_xml.c
+++ b/src/tmx_xml.c
@@ -268,10 +268,10 @@ static int parse_object(xmlTextReaderPtr reader, tmx_object *obj, int is_on_map,
 		if (rc_mgr) {
 			tmpl = (resource_holder*) hashtable_get((void*)rc_mgr, value);
 			if (tmpl && tmpl->type == RC_TX) {
-				obj->template = tmpl->resource.template;
+				obj->template_ref = tmpl->resource.template;
 			}
 		}
-		if (!(obj->template)) {
+		if (!(obj->template_ref)) {
 			if (!(ab_path = mk_absolute_path(filename, value))) return 0;
 			if (!(sub_reader = xmlReaderForFile(ab_path, NULL, 0))) { /* opens */
 				tmx_err(E_XDATA, "xml parser: cannot open object template file '%s'", ab_path);
@@ -279,20 +279,20 @@ static int parse_object(xmlTextReaderPtr reader, tmx_object *obj, int is_on_map,
 				tmx_free_func(value);
 				return 0;
 			}
-			obj->template = parse_template_document(sub_reader, rc_mgr, ab_path); /* and parses the template file */
+			obj->template_ref = parse_template_document(sub_reader, rc_mgr, ab_path); /* and parses the template file */
 			tmx_free_func(ab_path);
-			if (!(obj->template))
+			if (!(obj->template_ref))
 			{
 				tmx_free_func(value);
 				return 0;
 			}
 			if (rc_mgr) {
-				add_template(rc_mgr, value, obj->template);
+				add_template(rc_mgr, value, obj->template_ref);
 			} else {
-				obj->template->is_embedded = 1;
+				obj->template_ref->is_embedded = 1;
 			}
 		}
-		obj->obj_type = obj->template->object->obj_type;
+		obj->obj_type = obj->template_ref->object->obj_type;
 		tmx_free_func(value);
 	}
 


### PR DESCRIPTION
When tmx.h is included inside a C++ file, Microsoft Visual C++ doesn't allow the use of "template" keyword even if the file is included inside "extern C", as suggested on #35 