### PR TITLE
Add XML custom loader overrides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 
 include(FindLibXml2)
 find_package(LibXml2 REQUIRED)
-include_directories(${LIBXML2_INCLUDE_DIR})	target_link_libraries(tmx LibXml2::LibXml2)
+include_directories(${LIBXML2_INCLUDE_DIR})
 list(APPEND libs ${LIBXML2_LIBRARIES})
 
 # -- Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,8 @@ endif()
 
 include(FindLibXml2)
 find_package(LibXml2 REQUIRED)
-target_link_libraries(tmx LibXml2::LibXml2)
+include_directories(${LIBXML2_INCLUDE_DIR})	target_link_libraries(tmx LibXml2::LibXml2)
+list(APPEND libs ${LIBXML2_LIBRARIES})
 
 # -- Build
 

--- a/src/tmx_xml.c
+++ b/src/tmx_xml.c
@@ -22,7 +22,7 @@ xmlTextReaderPtr (*tmx_xml_reader_load_func) (const char *path, const char *enco
 void  (*tmx_xml_reader_free_func) (xmlTextReaderPtr reader) = NULL;
 
 static void
-set_xml_functions()
+set_xml_functions(void)
 {
 	if (!tmx_xml_reader_load_func) { tmx_xml_reader_load_func = xmlReaderForFile; }
 	if (!tmx_xml_reader_free_func) { tmx_xml_reader_free_func = xmlFreeTextReader; }

--- a/src/tmx_xml.h
+++ b/src/tmx_xml.h
@@ -1,0 +1,23 @@
+#ifndef TMX_XML_H
+#define TMX_XML_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "tmx.h"
+
+#include <libxml/xmlreader.h>
+
+/*
+   - Loaders -
+	 This functions override the default XML loaders if you want to use an external filesystem instead.
+ */
+TMXEXPORT extern xmlTextReaderPtr (*tmx_xml_reader_load_func) (const char *path, const char *encoding, int options);
+TMXEXPORT extern void  (*tmx_xml_reader_free_func) (xmlTextReaderPtr reader);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This replaces the `xmlReaderForFile` and `xmlFreeTextReader` to use instead tmx custom functions instead.

This allows to use PhysFS or other virtual filesystems without much trouble.

I attempted to copy the style used for `tmx_img_load_func` and `tmx_img_free_func` as much as I could.

To override this functions and to keep old headers intact, you should require "tmx_xml.h" first.
