### PR TITLE
Add `src` to the include directories for `tmx` when building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ endif()
 
 # --  Installation
 
-target_include_directories(tmx INTERFACE $<INSTALL_INTERFACE:include>)
+target_include_directories(tmx INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src> $<INSTALL_INTERFACE:include>)
 
 configure_file("tmxConfig.cmake.in" "tmxConfig.cmake" @ONLY)
 


### PR DESCRIPTION
When using this library as a submodule of another project, we have to
manually add the `src` directory to the include path.

If there is no installation to be done, we want all dependent targets to
have the right include path.