### PR TITLE
On tmx_img_load_func, add a void *data argument which allows the user…

### DIFF
--- a/doc/src/override.rst
+++ b/doc/src/override.rst
@@ -53,7 +53,7 @@ Image Autoload/Autofree
 Set (there is no default implementation) load and free functions to load/free images automatically as they are read in
 the map source.
 
-.. c:var:: void* (*tmx_img_load_func) (const char *path)
+.. c:var:: void* (*tmx_img_load_func) (const char *path, void *data)
 
    Load the resource (image) at the given path, return a pointer to void.
    The returned value is then stored in a :c:member:`tmx_image.resource_image`.

--- a/doc/src/renderer-from-scratch.rst
+++ b/doc/src/renderer-from-scratch.rst
@@ -203,19 +203,21 @@ an easier way to do that without the hassle: :ref:`callback functions <image-aut
 | **libTMX** can use two callback functions to delegate the image loading and image freeing to your library/engine.
 | One callback to load: :c:data:`tmx_img_load_func`.
 | One callback to free: :c:data:`tmx_img_free_func`.
+| Optional pointer to any data needed by your load function: :c:data:`tmx_img_load_data`.
 | These callbacks **must be set BEFORE you call any load function**.
 
 .. tabs::
 
    .. code-tab:: c SDL 2
 
-         void* SDL_tex_loader(const char *path) {
-           return IMG_LoadTexture(ren, path);
+         void* SDL_tex_loader(const char *path, void *data) {
+           return IMG_LoadTexture((SDL_Renderer*)data, path);
          }
 
          /* Set the callback globs in the main function */
          tmx_img_load_func = SDL_tex_loader;
          tmx_img_free_func = (void (*)(void*))SDL_DestroyTexture;
+         tmx_img_load_data = ren;
 
          tmx_map *map = tmx_load(argv[1]);
          /* ... */
@@ -223,7 +225,7 @@ an easier way to do that without the hassle: :ref:`callback functions <image-aut
 
    .. code-tab:: c Allegro 5
 
-         void* Allegro5_tex_loader(const char *path) {
+         void* Allegro5_tex_loader(const char *path, void *data) {
            ALLEGRO_BITMAP *res    = NULL;
            ALLEGRO_PATH   *alpath = NULL;
 
@@ -247,7 +249,7 @@ an easier way to do that without the hassle: :ref:`callback functions <image-aut
 
    .. code-tab:: c raylib
 
-         void* raylib_tex_loader(const char *path) {
+         void* raylib_tex_loader(const char *path, void *data) {
            Texture2D *returnValue = malloc(sizeof(Texture2D));
            *returnValue = LoadTexture(path);
            return returnValue;

--- a/examples/allegro/allegro.c
+++ b/examples/allegro/allegro.c
@@ -7,7 +7,7 @@
 #define DISPLAY_H 600
 #define DISPLAY_W 800
 
-void* Allegro5_tex_loader(const char *path) {
+void* Allegro5_tex_loader(const char *path, void *data) {
 	ALLEGRO_BITMAP *res    = NULL;
 	ALLEGRO_PATH   *alpath = NULL;
 

--- a/examples/raylib/raylib.c
+++ b/examples/raylib/raylib.c
@@ -6,7 +6,7 @@
 #define DISPLAY_H 600
 #define DISPLAY_W 800
 
-void *raylib_tex_loader(const char *path) {
+void *raylib_tex_loader(const char *path, void *data) {
 	Texture2D *returnValue = malloc(sizeof(Texture2D));
 	*returnValue = LoadTexture(path);
 	return returnValue;

--- a/src/tmx.c
+++ b/src/tmx.c
@@ -10,8 +10,9 @@
 
 void* (*tmx_alloc_func) (void *address, size_t len) = NULL;
 void  (*tmx_free_func ) (void *address) = NULL;
-void* (*tmx_img_load_func) (const char *p) = NULL;
+void* (*tmx_img_load_func) (const char *p, void *data) = NULL;
 void  (*tmx_img_free_func) (void *address) = NULL;
+void*   tmx_img_load_data = NULL;
 
 /*
 	Public functions

--- a/src/tmx.h
+++ b/src/tmx.h
@@ -38,9 +38,12 @@ TMXEXPORT extern void* (*tmx_alloc_func) (void *address, size_t len); /* realloc
 TMXEXPORT extern void  (*tmx_free_func ) (void *address);             /* free */
 
 /* load/free tmx_image->resource_image, you should set this if you want
-   the library to load/free images */
-TMXEXPORT extern void* (*tmx_img_load_func) (const char *path);
+   the library to load/free images. Optionally, you can point tmx_img_load_data
+   to any memory needed by your loader function, and it will be accessed as 
+   the data argument */
+TMXEXPORT extern void* (*tmx_img_load_func) (const char *path, void *data);
 TMXEXPORT extern void  (*tmx_img_free_func) (void *address);
+TMXEXPORT extern void*   tmx_img_load_data; 
 
 /*
 	Data Structures

--- a/src/tmx_utils.c
+++ b/src/tmx_utils.c
@@ -609,7 +609,7 @@ void* load_image(void **ptr, const char *base_path, const char *rel_path) {
 	if (tmx_img_load_func) {
 		ap_img = mk_absolute_path(base_path, rel_path);
 		if (!ap_img) return 0;
-		*ptr = tmx_img_load_func(ap_img);
+		*ptr = tmx_img_load_func(ap_img, tmx_img_load_data);
 		tmx_free_func(ap_img);
 		return(*ptr);
 	}


### PR DESCRIPTION
… to point to any memory needed by their loader function which defeats the need of making more globals for them and allows for cleaner code.

Update documentation to reflect the changes.
Add global pointer tmx_img_load_data which allows the user to supply any additional memory needed by their loader in a clean way like a struct making the lib more flexible. Such example would be an SDL_Renderer pointer defined inside a scope.