### PR TITLE
Change strtol to strtoul

### DIFF
--- a/src/tmx_utils.c
+++ b/src/tmx_utils.c
@@ -511,7 +511,7 @@ uint32_t get_color_rgb(const char *c) {
 	uint32_t res;
 	if (*c == '#') c++;
 	clen = strlen(c);
-	res = (uint32_t)strtol(c, NULL, 16);
+	res = (uint32_t)strtoul(c, NULL, 16);
 	if (clen < 6) {
 		res = (res & 0xF000u) << 16 | (res & 0xF000u) << 12 /* AXXX */
 		    | (res & 0x0F00u) << 12 | (res & 0x0F00u) <<  8 /* XRXX */


### PR DESCRIPTION
The function strtol() is not able to convert numbers that are larger than LONG_MAX and smaller than LONG_MIN as it uses signed numbers.
This can cause issues on different platforms; strtoul() should be used for unsigned long integers.
_Discovered when trying to compile code with i686-w64-mingw32-gcc for Windows._