### PR TITLE
Add parallax to the layer from Tiled 1.5

### DIFF
--- a/examples/dumper/dumper.c
+++ b/examples/dumper/dumper.c
@@ -308,6 +308,8 @@ void dump_layer(tmx_layer *l, unsigned int tc, int depth) {
 		printf("\n%s\t" "opacity='%f'", padding, l->opacity);
 		printf("\n%s\t" "offsetx=%d", padding, l->offsetx);
 		printf("\n%s\t" "offsety=%d", padding, l->offsety);
+		printf("\n%s\t" "parallaxx=%d", padding, l->parallaxx);
+		printf("\n%s\t" "parallaxy=%d", padding, l->parallaxy);
 		printf("\n%s\t" "tintcolor=#%.6X", padding, l->tintcolor);
 		if (l->type == L_LAYER && l->content.gids) {
 			printf("\n%s\t" "type=Layer" "\n%s\t" "tiles=", padding, padding);

--- a/src/tmx.h
+++ b/src/tmx.h
@@ -212,6 +212,7 @@ struct _tmx_layer { /* <layer> or <imagelayer> or <objectgroup> */
 	double opacity;
 	int visible; /* 0 == false */
 	int offsetx, offsety;
+	double parallaxx, parallaxy;
 	uint32_t tintcolor; /* bytes : ARGB */
 
 	enum tmx_layer_type type;

--- a/src/tmx_xml.c
+++ b/src/tmx_xml.c
@@ -519,6 +519,16 @@ static int parse_layer(xmlTextReaderPtr reader, tmx_layer **layer_headadr, int m
 		tmx_free_func(value);
 	}
 
+	if ((value = (char*)xmlTextReaderGetAttribute(reader, (xmlChar*)"parallaxx"))) { /* parallaxx */
+		res->parallaxx = atof(value);
+		tmx_free_func(value);
+	}
+
+	if ((value = (char*)xmlTextReaderGetAttribute(reader, (xmlChar*)"parallaxy"))) { /* parallaxy */
+		res->parallaxy = atof(value);
+		tmx_free_func(value);
+	}
+
 	if ((value = (char*)xmlTextReaderGetAttribute(reader, (xmlChar*)"tintcolor"))) { /* tintcolor */
 		res->tintcolor = get_color_rgb(value);
 		tmx_free_func(value);


### PR DESCRIPTION
The [TMX Map Format](https://doc.mapeditor.org/en/stable/reference/tmx-map-format/) now has `parallax` values for both x and y.