### PR TITLE
Add tmx_load_buffer_path() for loading with virtual paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@ cmake-build*/
 
 # ide
 /.idea
+/.vscode
+
+# cmake
+CMakeCache.txt
+Makefile
+cmake_install.cmake
+CMakeFiles/

--- a/doc/src/functions.rst
+++ b/doc/src/functions.rst
@@ -35,7 +35,7 @@ Load maps
 External resources
 ------------------
 
-libTMX has a resource manager to store tilesets and object templates to avoid loading them twice or more.  
+libTMX has a resource manager to store tilesets and object templates to avoid loading them twice or more.
 
 .. c:type:: tmx_resource_manager
 
@@ -108,6 +108,24 @@ Maps
 .. c:function:: tmx_map* tmx_rcmgr_load_callback(tmx_resource_manager *rc_mgr, tmx_read_functor callback, void *userdata)
 
    Load a TMX map using a callback function as defined above. `userdata` is passed as-is.
+   See :c:type:`tmx_read_functor`.
+
+Variants with virtual paths
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In case you're working with a virtual file system, you may use these variants accepting a virtual path:
+
+.. c:function:: tmx_map* tmx_rcmgr_load_buffer_vpath(tmx_resource_manager *rc_mgr, const char *buffer, int len, const char *vpath)
+
+   Load a TMX map from the given buffer whose length is len, with a given virtual path.
+
+.. c:function:: tmx_map* tmx_rcmgr_load_fd_vpath(tmx_resource_manager *rc_mgr, int fd, const char *vpath)
+
+   Load a TMX map from a C file descriptor, with a given virtual path.
+
+.. c:function:: tmx_map* tmx_rcmgr_load_callback_vpath(tmx_resource_manager *rc_mgr, tmx_read_functor callback, const char *vpath, void *userdata)
+
+   Load a TMX map using a callback function as defined above. `userdata` is passed as-is, with a given virtual path.
    See :c:type:`tmx_read_functor`.
 
 Utilities

--- a/src/tmx.c
+++ b/src/tmx.c
@@ -201,25 +201,37 @@ tmx_map* tmx_rcmgr_load(tmx_resource_manager *rc_mgr, const char *path) {
 }
 
 tmx_map* tmx_rcmgr_load_buffer(tmx_resource_manager *rc_mgr, const char *buffer, int len) {
-	tmx_map *map = NULL;
-	set_alloc_functions();
-	map = parse_xml_buffer(rc_mgr, buffer, len);
-	map_post_parsing(&map);
-	return map;
+	return tmx_rcmgr_load_buffer_vpath(rc_mgr, buffer, len, NULL);
 }
 
 tmx_map* tmx_rcmgr_load_fd(tmx_resource_manager *rc_mgr, int fd) {
+	return tmx_rcmgr_load_fd_vpath(rc_mgr, fd, NULL);
+}
+
+tmx_map* tmx_rcmgr_load_callback(tmx_resource_manager *rc_mgr, tmx_read_functor callback, void *userdata) {
+	return tmx_rcmgr_load_callback_vpath(rc_mgr, callback, NULL, userdata);
+}
+
+tmx_map* tmx_rcmgr_load_buffer_vpath(tmx_resource_manager *rc_mgr, const char *buffer, int len, const char *vpath) {
 	tmx_map *map = NULL;
 	set_alloc_functions();
-	map = parse_xml_fd(rc_mgr, fd);
+	map = parse_xml_buffer_vpath(rc_mgr, buffer, len, vpath);
 	map_post_parsing(&map);
 	return map;
 }
 
-tmx_map* tmx_rcmgr_load_callback(tmx_resource_manager *rc_mgr, tmx_read_functor callback, void *userdata) {
+tmx_map* tmx_rcmgr_load_fd_vpath(tmx_resource_manager *rc_mgr, int fd, const char *vpath) {
 	tmx_map *map = NULL;
 	set_alloc_functions();
-	map = parse_xml_callback(rc_mgr, callback, userdata);
+	map = parse_xml_fd_vpath(rc_mgr, fd, vpath);
+	map_post_parsing(&map);
+	return map;
+}
+
+tmx_map* tmx_rcmgr_load_callback_vpath(tmx_resource_manager *rc_mgr, tmx_read_functor callback, const char *vpath, void *userdata) {
+	tmx_map *map = NULL;
+	set_alloc_functions();
+	map = parse_xml_callback_vpath(rc_mgr, callback, vpath, userdata);
 	map_post_parsing(&map);
 	return map;
 }

--- a/src/tmx.h
+++ b/src/tmx.h
@@ -389,6 +389,23 @@ TMXEXPORT tmx_map* tmx_rcmgr_load_fd(tmx_resource_manager *rc_mgr, int fd);
 TMXEXPORT tmx_map* tmx_rcmgr_load_callback(tmx_resource_manager *rc_mgr, tmx_read_functor callback, void *userdata);
 
 /*
+	Load map with virtual paths
+*/
+
+/* Loads a map from buffer, and returns the head of the data structure
+   returns NULL if an error occurred and set tmx_errno */
+TMXEXPORT tmx_map* tmx_rcmgr_load_buffer_vpath(tmx_resource_manager *rc_mgr, const char *buffer, int len, const char* vpath);
+
+/* Loads a map from a file descriptor and returns the head of the data structure
+   The file descriptor will not be closed
+   returns NULL if an error occurred and set tmx_errno */
+TMXEXPORT tmx_map* tmx_rcmgr_load_fd_vpath(tmx_resource_manager *rc_mgr, int fd, const char* vpath);
+
+/* Loads a map using the given read callback and returns the head of the data structure
+   returns NULL if an error occurred and set tmx_errno */
+TMXEXPORT tmx_map* tmx_rcmgr_load_callback_vpath(tmx_resource_manager *rc_mgr, tmx_read_functor callback, const char* vpath, void *userdata);
+
+/*
 	Error handling
 	each time a function fails, tmx_errno is set
 */

--- a/src/tmx_utils.h
+++ b/src/tmx_utils.h
@@ -33,8 +33,11 @@ int add_template(tmx_resource_manager *rc_mgr, const char *key, tmx_template *va
 */
 tmx_map* parse_xml(tmx_resource_manager *rc_mgr, const char *filename);
 tmx_map* parse_xml_buffer(tmx_resource_manager *rc_mgr, const char *buffer, int len);
+tmx_map* parse_xml_buffer_vpath(tmx_resource_manager *rc_mgr, const char *buffer, int len, const char *vpath);
 tmx_map* parse_xml_fd(tmx_resource_manager *rc_mgr, int fd);
+tmx_map* parse_xml_fd_vpath(tmx_resource_manager *rc_mgr, int fd, const char *vpath);
 tmx_map* parse_xml_callback(tmx_resource_manager *rc_mgr, tmx_read_functor callback, void *userdata);
+tmx_map* parse_xml_callback_vpath(tmx_resource_manager *rc_mgr, tmx_read_functor callback, const char *vpath, void *userdata);
 
 tmx_tileset* parse_tsx_xml(const char *filename);
 tmx_tileset* parse_tsx_xml_buffer(const char *buffer, int len);

--- a/src/tmx_xml.c
+++ b/src/tmx_xml.c
@@ -217,7 +217,7 @@ static int parse_text(xmlTextReaderPtr reader, tmx_text *text) {
 		text->halign = parse_horizontal_align(value);
 		tmx_free_func(value);
 	}
-	
+
 	if ((value = (char*)xmlTextReaderGetAttribute(reader, (xmlChar*)"valign"))) { /* valign */
 		text->valign = parse_vertical_align(value);
 		tmx_free_func(value);
@@ -1145,13 +1145,17 @@ tmx_map *parse_xml(tmx_resource_manager *rc_mgr, const char *filename) {
 }
 
 tmx_map* parse_xml_buffer(tmx_resource_manager *rc_mgr, const char *buffer, int len) {
+	parse_xml_buffer_vpath(rc_mgr, buffer, len, NULL);
+}
+
+tmx_map* parse_xml_buffer_vpath(tmx_resource_manager *rc_mgr, const char *buffer, int len, const char *vpath) {
 	xmlTextReaderPtr reader;
 	tmx_map *res = NULL;
 
 	setup_libxml_mem();
 
 	if ((reader = xmlReaderForMemory(buffer, len, NULL, NULL, 0))) {
-		res = parse_map_document(reader, rc_mgr, NULL);
+		res = parse_map_document(reader, rc_mgr, vpath);
 	} else {
 		tmx_err(E_UNKN, "xml parser: unable to create parser for buffer");
 	}
@@ -1160,13 +1164,17 @@ tmx_map* parse_xml_buffer(tmx_resource_manager *rc_mgr, const char *buffer, int 
 }
 
 tmx_map* parse_xml_fd(tmx_resource_manager *rc_mgr, int fd) {
+	return parse_xml_fd_vpath(rc_mgr, fd, NULL);
+}
+
+tmx_map* parse_xml_fd_vpath(tmx_resource_manager *rc_mgr, int fd, const char *vpath) {
 	xmlTextReaderPtr reader;
 	tmx_map *res = NULL;
 
 	setup_libxml_mem();
 
 	if ((reader = xmlReaderForFd(fd, NULL, NULL, 0))) {
-		res = parse_map_document(reader, rc_mgr, NULL);
+		res = parse_map_document(reader, rc_mgr, vpath);
 	} else {
 		tmx_err(E_UNKN, "xml parser: unable create parser for file descriptor");
 	}
@@ -1175,13 +1183,17 @@ tmx_map* parse_xml_fd(tmx_resource_manager *rc_mgr, int fd) {
 }
 
 tmx_map* parse_xml_callback(tmx_resource_manager *rc_mgr, tmx_read_functor callback, void *userdata) {
+	return parse_xml_callback_vpath(rc_mgr, callback, NULL, userdata);
+}
+
+tmx_map* parse_xml_callback_vpath(tmx_resource_manager *rc_mgr, tmx_read_functor callback, const char *vpath, void *userdata) {
 	xmlTextReaderPtr reader;
 	tmx_map *res = NULL;
 
 	setup_libxml_mem();
 
 	if ((reader = xmlReaderForIO((xmlInputReadCallback)callback, NULL, userdata, NULL, NULL, 0))) {
-		res = parse_map_document(reader, rc_mgr, NULL);
+		res = parse_map_document(reader, rc_mgr, vpath);
 	} else {
 		tmx_err(E_UNKN, "xml parser: unable to create parser for input callback");
 	}


### PR DESCRIPTION
This change introduces a new function to allow loading a map buffer, while setting a virtual path for it. Allows for loading buffers, while controlling where its associated images are loaded from. Fixes #57