### PR TITLE
Documentation: Fix raylib code samples (draw_tile)

### DIFF
--- a/doc/src/renderer-from-scratch.rst
+++ b/doc/src/renderer-from-scratch.rst
@@ -437,7 +437,7 @@ Tile layers
 
       void draw_tile(void *image, unsigned int sx, unsigned int sy, unsigned int sw, unsigned int sh,
                      unsigned int dx, unsigned int dy, float opacity, unsigned int flags) {
-        DrawTextureRec((Texture2D*)image, (Rectangle) {sx, sy, sw, sh}, (Vector2) {dx, dy}, (Color) {opacity, opacity, opacity, opacity});
+        DrawTextureRec(*(Texture2D*)image, (Rectangle) {sx, sy, sw, sh}, (Vector2) {dx, dy}, ColorAlpha(WHITE, opacity));
       }
 
 Object layers


### PR DESCRIPTION
This PR refers to the page [Creating a map renderer from scratch](https://libtmx.readthedocs.io/en/latest/renderer-from-scratch.html). The `draw_tile()` implementation there is faulty and leads to a black screen.

Here are my proposed fixes:

1. Fixed `DrawTextureRec()` call by derefing `image` as the function requires a `Texture2D` variable instead of a `Texture2D*` pointer
2. Fixed the Alpha issue: raylib's `Color` struct works with 4 `uint` fields (r, g, b, a). Passing opacity directly will result in a `rgba(1,1,1,1)` color (black). Adopted `WHITE` as default and applied `opacity` as its alpha

The above was tested with most recent Raylib's version: 3.7.0