### PR TITLE
Fix libxml2 lookup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,6 @@ else()
     message("zstd not wanted")
 endif()
 
-include(FindLibXml2)
 find_package(LibXml2 REQUIRED)
 target_link_libraries(tmx LibXml2::LibXml2)
 


### PR DESCRIPTION
`find_package` is enough to load the LibXml2 package, no matter if Find module or Config.
And `FindLibXml2.cmake` isn't meant to be used with `include`: being a Find module, it interacts with package interface variables which are set only with `find_package`.
In the end this can break the build when Config is preferred over Find modules, due to inconsistent target sets: 
https://github.com/microsoft/vcpkg/pull/24935#issuecomment-1177115255